### PR TITLE
Implement gc at the LevelDB layer

### DIFF
--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -86,12 +86,15 @@ func PruneAppState(dataDir string) error {
 		appStore.PruneStores(targetHeight)
 	}
 
-	if err := runGC(dataDir, "application", o, appDB); err != nil {
-		return err
-	}
-	appDB, err = db.NewGoLevelDBWithOpts("application", dataDir, &o)
-	if err != nil {
-		return err
+	if gcApplication {
+		if err := runGC(dataDir, "application", o, appDB); err != nil {
+			return err
+		}
+		appDB, err = db.NewGoLevelDBWithOpts("application", dataDir, &o)
+		if err != nil {
+			logger.Error("failed to re-open application")
+			return err
+		}
 	}
 	logger.Info("compacting application state")
 	return appDB.ForceCompact(nil, nil)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,11 +14,12 @@ var (
 )
 
 var (
-	cosmosSdk    bool
-	cometbft     bool
-	keepBlocks   uint64
-	keepVersions uint64
-	appName      = "cosmprund"
+	cosmosSdk     bool
+	cometbft      bool
+	keepBlocks    uint64
+	gcApplication bool
+	keepVersions  uint64
+	appName       = "cosmprund"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -34,6 +35,7 @@ func NewRootCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dataDir := args[0]
+			gcApplication = viper.GetBool("gc-application")
 
 			if cosmosSdk {
 				if err := PruneAppState(dataDir); err != nil {
@@ -53,6 +55,11 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(pruneCmd)
 
+	// --gc-application flag
+	pruneCmd.PersistentFlags().Bool("gc-application", false, "whether to run GC on the application DB")
+	if err := viper.BindPFlag("gc-application", pruneCmd.PersistentFlags().Lookup("gc-application")); err != nil {
+		panic(err)
+	}
 	// --keep-blocks flag
 	pruneCmd.PersistentFlags().Uint64VarP(&keepBlocks, "keep-blocks", "b", 10, "set the amount of blocks to keep")
 	if err := viper.BindPFlag("keep-blocks", pruneCmd.PersistentFlags().Lookup("keep-blocks")); err != nil {


### PR DESCRIPTION
LevelDB, like all LSM databases, doesn't frequently delete on-disk data; instead these items get marked as "stale" (on update) or "tombstoned" (on delete).

There is no mechanism to "defragment" or "vacuum" these stale values out of the database; the only option is to "copy" the latest value (if not tombstoned) of each key to a new database.

This "runGC" function implements just that. On a test database, it reduced the size from 61GB to 12GB on disk.