### PR TITLE
Prune commit info from application DB

### DIFF
--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -89,6 +89,14 @@ func PruneAppState(dataDir string) error {
 		logger.Info("Pruning up to", "targetHeight", targetHeight)
 
 		appStore.PruneStores(targetHeight)
+
+		logger.Info("Purging commit info from application.db", "targetHeight", ver-1)
+		prunedS, err := deleteHeightRange(appAdpt, "s/", 0, uint64(targetHeight)-1)
+		if err != nil {
+			logger.Error("failed to deleteHeightRange")
+			return err
+		}
+		logger.Info("purged", "count", prunedS)
 	}
 
 	if gcApplication {


### PR DESCRIPTION
In the same vein as the blockstore change, this pruges the commint information from the application database.

Data from a story sentry was reduced from 13GB to 200MB.

Tested & working fine on 3 chains