### PR TITLE
Support sei pruning

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -47,7 +47,8 @@ func unmarshalSeiState(stateBytes []byte) (State, error) {
 	err := proto.Unmarshal(stateBytes, &stateData)
 	return &stateData, err
 }
-func ShowDbState(dataDir string) (*LatestState, error) {
+
+func DbState(dataDir string) (*LatestState, error) {
 	levelOptions := opt.Options{
 		ReadOnly: true,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,12 +16,12 @@ var (
 )
 
 var (
-	cosmosSdk     bool
-	cometbft      bool
-	keepBlocks    uint64
-	gcApplication bool
-	keepVersions  uint64
-	appName       = "cosmprund"
+	cosmosSdk    bool
+	cometbft     bool
+	keepBlocks   uint64
+	runGC        bool
+	keepVersions uint64
+	appName      = "cosmprund"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -37,7 +37,6 @@ func NewRootCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dataDir := args[0]
-			gcApplication = viper.GetBool("gc-application")
 			logger = log.NewLogger(os.Stderr, setConfig)
 
 			if cosmosSdk {
@@ -60,13 +59,13 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(pruneCmd)
 
-	// --gc-application flag
-	pruneCmd.PersistentFlags().Bool("gc-application", false, "whether to run GC on the application DB")
-	if err := viper.BindPFlag("gc-application", pruneCmd.PersistentFlags().Lookup("gc-application")); err != nil {
+	// --run-gc flag
+	pruneCmd.PersistentFlags().BoolVar(&runGC, "run-gc", true, "set to false to prevent a GC pass")
+	if err := viper.BindPFlag("run-gc", pruneCmd.PersistentFlags().Lookup("run-gc")); err != nil {
 		panic(err)
 	}
 	// --keep-blocks flag
-	pruneCmd.PersistentFlags().Uint64VarP(&keepBlocks, "keep-blocks", "b", 10, "set the amount of blocks to keep")
+	pruneCmd.PersistentFlags().Uint64VarP(&keepBlocks, "keep-blocks", "b", 100, "set the amount of blocks to keep")
 	if err := viper.BindPFlag("keep-blocks", pruneCmd.PersistentFlags().Lookup("keep-blocks")); err != nil {
 		panic(err)
 	}
@@ -105,7 +104,7 @@ func NewRootCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dataDir := args[0]
 
-			dbState, err := ShowDbState(dataDir)
+			dbState, err := DbState(dataDir)
 			if err != nil {
 				fmt.Printf("failed %v\n", err)
 				return err

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.3 // indirect


### PR DESCRIPTION
This PR adds support for sei's "custom" keys on state/block store, which are binary keys using orderedcode instead of ascii keys.

A little bit of extra code crept in (handling P:, better handling of GC and renaming --gc-application flag)

This stacks on top of #8 