### PR TITLE
Allow forcing compression of application.db

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,28 @@ sudo systemctl stop cosmovisor
 
 Flags: 
 
-- `blocks`: amount of blocks to keep on the node (Default 100)
-- `versions`: amount of app state versions to keep on the node (Default 10)
-- `cosmos-sdk`: If pruning a non cosmos-sdk chain, like Nomic, you only want to use cometbft pruning or if you want to only prune cometbft block & state as this is generally large on machines(Default true)
-- `cometbft`: If the user wants to only prune application data they can disable pruning of cometbft data. (Default true)
+```
+Flags:
+      --cometbft             set to false you dont want to prune cometbft data (default true)
+      --cosmos-sdk           set to false if using only with cometbft (default true)
+      --force-compress-app   compress application.db even if it's larger than reasonable (10 GB)
+                             The entire database needs to be read, so it will be slow
+  -h, --help                 help for prune
+  -b, --keep-blocks uint     set the amount of blocks to keep (default 100)
+  -v, --keep-versions uint   set the amount of versions to keep in the application store (default 10)
+      --run-gc               set to false to prevent a GC pass (default true)
+```
+
+## Shortcomings
+
+Not all stores are pruned, though usually `block`, `state` and `application` are the bulk of the data.
+
+Within the `application` store, this tool currently only purges old states (`s/` keys). Some chains store extra data here, and each chain required custom logic to prune it.
+
+If you have a chain with a large `application` dir, you can try running statesync every once in a while to reduce it, alternatively, make an issue in this repo and we'll see if it can be pruned externally.
+
+If no historical data is stored in `application.db`, it's usually pruned to a few (~50) MB. If there's significant historical data, then `application.db` will be large (20+GB); these cases are not supported yet,
+so using a large value for `--compress-app-under-gb` is not likely to achieve much.
 
 ## Metadata
 

--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -22,6 +22,7 @@ import (
 )
 
 const GiB uint64 = 1073741824 // 2**30
+const THRESHOLD_APP_SIZE uint64 = 10 * GiB
 
 var logger log.Logger
 
@@ -244,14 +245,14 @@ func PruneCmtData(dataDir string) error {
 				logger.Error("Failed to get dir size for app.db, skipping GC", "err", err)
 				return err
 			}
-			if size < 10*GiB {
-				logger.Info("Starting application DB GC/compact as it's smaller than 10GB", "sizeGB", size/GiB)
+			if size < THRESHOLD_APP_SIZE*GiB || forceCompressApp {
+				logger.Info("Starting application DB GC/compact", "sizeGB", size/GiB, "thresholdGB", THRESHOLD_APP_SIZE/GiB, "forced", forceCompressApp)
 				if err := gcDB(dataDir, "application", appStoreDB, dbfmt); err != nil {
 					logger.Error("Failed to run gcDB", "err", err, "application", appStoreDB, "dbfmt", dbfmt)
 					return err
 				}
 			} else {
-				logger.Info("Skipping application DB GC/compact as it's bigger than 10GB", "sizeGB", size/GiB)
+				logger.Info("Skipping application DB GC/compact", "sizeGB", size/GiB, "thresholdGB", THRESHOLD_APP_SIZE/GiB, "forced", forceCompressApp)
 			}
 			return nil
 		})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,12 +17,13 @@ var (
 )
 
 var (
-	cosmosSdk    bool
-	cometbft     bool
-	keepBlocks   uint64
-	runGC        bool
-	keepVersions uint64
-	appName      = "cosmprund"
+	cosmosSdk        bool
+	cometbft         bool
+	keepBlocks       uint64
+	runGC            bool
+	forceCompressApp bool
+	keepVersions     uint64
+	appName          = "cosmprund"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -75,6 +76,11 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(pruneCmd)
 
+	// --force-compress-app flag
+	pruneCmd.PersistentFlags().BoolVar(&forceCompressApp, "force-compress-app", false, fmt.Sprintf("compress application.db even if it's larger than reasonable (%d GB)\nThe entire database needs to be read, so it will be slow", THRESHOLD_APP_SIZE/GiB))
+	if err := viper.BindPFlag("force-compress-app", pruneCmd.PersistentFlags().Lookup("force-compress-app")); err != nil {
+		panic(err)
+	}
 	// --run-gc flag
 	pruneCmd.PersistentFlags().BoolVar(&runGC, "run-gc", true, "set to false to prevent a GC pass")
 	if err := viper.BindPFlag("run-gc", pruneCmd.PersistentFlags().Lookup("run-gc")); err != nil {


### PR DESCRIPTION
This PR allows the user to bypass the arbitrary limit of 10GiB when deciding whether to compress (GC) or not the application store