### PR TITLE
Set blockstore base when pruning

### DIFF
--- a/cmd/pruner.go
+++ b/cmd/pruner.go
@@ -204,6 +204,7 @@ func PruneCmtData(dataDir string) error {
 
 	logger.Info("Initial state", "ChainId", curState.ChainID, "LastBlockHeight", curState.LastBlockHeight)
 	pruneHeight := uint64(curState.LastBlockHeight) - keepBlocks
+	logger.Info("Pruning up to", "targetHeight", pruneHeight)
 	isSei := slices.Contains([]string{"pacific-1", "atlantic-2"}, curState.ChainID)
 
 	if !isSei {

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.2 // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
+	github.com/cometbft/cometbft/api v1.0.0 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAK
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/cometbft/cometbft v0.38.12 h1:OWsLZN2KcSSFe8bet9xCn07VwhBnavPea3VyPnNq1bg=
 github.com/cometbft/cometbft v0.38.12/go.mod h1:GPHp3/pehPqgX1930HmK1BpBLZPxB75v/dZg8Viwy+o=
+github.com/cometbft/cometbft/api v1.0.0 h1:gGBwvsJi/gnHJEtwYfjPIGs2AKg/Vfa1ZuKCPD1/Ko4=
+github.com/cometbft/cometbft/api v1.0.0/go.mod h1:EkQiqVSu/p2ebrZEnB2z6Re7r8XNe//M7ylR0qEwWm0=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cosmos/cosmos-db v1.0.2 h1:hwMjozuY1OlJs/uh6vddqnk9j7VamLv+0DBlbEXbAKs=
 github.com/cosmos/cosmos-db v1.0.2/go.mod h1:Z8IXcFJ9PqKK6BIsVOB3QXtkKoqUOp1vRvPT39kOXEA=


### PR DESCRIPTION
We were not setting the blockstore's base, which caused some chain software to start crashing.

The issue manifested when a peer connected and requested a block which the blockstore state said we had (height between base and height):
```
2025-06-05T08:10:16Z INFO Starting MConnection service module=p2p peer=... impl=MConn{...}
2025-06-05T08:10:17Z ERRR Failed to load block meta module=consensus peer=Peer{...} height=5934342 blockstoreBase=1 blockstoreHeight=5946232
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ba67a0]

goroutine 4638 [running]:
github.com/cometbft/cometbft/internal/consensus.(*PeerState).SetHasCatchupCommit(0x24e513c?, 0x0?)
      github.com/cometbft/cometbft@v1.0.1-0.20241220100824-07c737de00ff/internal/consensus/reactor.go:1525 +0x80
github.com/cometbft/cometbft/internal/consensus.(*PeerState).sendCommit(0xc000847e10, 0x0)
      github.com/cometbft/cometbft@v1.0.1-0.20241220100824-07c737de00ff/internal/consensus/reactor.go:1298 +0x173
github.com/cometbft/cometbft/internal/consensus.(*Reactor).gossipVotesRoutine(0xc001129b00, {0x29fb9d0, 0xc000b98f70}, 0xc000847e10)
      github.com/cometbft/cometbft@v1.0.1-0.20241220100824-07c737de00ff/internal/consensus/reactor.go:697 +0x445
created by github.com/cometbft/cometbft/internal/consensus.(*Reactor).AddPeer in goroutine 5447
      github.com/cometbft/cometbft@v1.0.1-0.20241220100824-07c737de00ff/internal/consensus/reactor.go:213 +0x150
```

The  code triggering this behavior, from cometbft, was:

```
    if prs.ProposalBlockParts == nil {
         blockMeta := blockStore.LoadBlockMeta(prs.Height)
         if blockMeta == nil {
                heightLogger.Error("Failed to load block meta",
                        "blockstoreBase", blockStoreBase, "blockstoreHeight", blockStore.Height())
                return nil, false
        }
```

but the caller of this, later, ignored the error and tried to dereference the nil pointer

The caller is wrong to dereference a nil pointer, but we can also prevent this by setting the correct Base on the block store.
