### PR TITLE
Prune validatorsKey from state.db

### DIFF
--- a/cmd/generic_chain.go
+++ b/cmd/generic_chain.go
@@ -44,6 +44,7 @@ var blockKeyInfos = []PrefixAndSplitter{
 var stateKeyInfos = []string{
 	"abciResponsesKey:",
 	"consensusParamsKey:",
+	"validatorsKey:",
 }
 
 var appKeyInfos = []string{


### PR DESCRIPTION
This key (`validatorsKey`) is used at least on gaia (cosmos) and it stores the public keys of validators on every block.

Pruning this from gaia reduced the snapshot by 1.2GB (~8%)